### PR TITLE
Ensure Crypt::PK::ECC->key2hash()->{curve_name} is lowercase

### DIFF
--- a/inc/CryptX_PK_ECC.xs.inc
+++ b/inc/CryptX_PK_ECC.xs.inc
@@ -145,7 +145,6 @@ key2hash(Crypt::PK::ECC self)
         }
         /* =====> curve_... */
         if (self->key.dp) {
-          not_used = hv_store(rv_hash, "curve_name",  10, newSVpv(self->key.dp->name,  strlen(self->key.dp->name)), 0);
           not_used = hv_store(rv_hash, "curve_prime", 11, newSVpv(self->key.dp->prime, strlen(self->key.dp->prime)), 0);
           not_used = hv_store(rv_hash, "curve_A",      7, newSVpv(self->key.dp->A,     strlen(self->key.dp->A)), 0);
           not_used = hv_store(rv_hash, "curve_B",      7, newSVpv(self->key.dp->B,     strlen(self->key.dp->B)), 0);
@@ -160,6 +159,17 @@ key2hash(Crypt::PK::ECC self)
             not_used = hv_store(rv_hash, "curve_bytes", 11, newSViv(mp_unsigned_bin_size(&p_num)), 0);
             not_used = hv_store(rv_hash, "curve_bits",  10, newSViv(mp_count_bits(&p_num)), 0);
             mp_clear(&p_num);
+          }
+          {
+            int i;
+            SV *name;
+            unsigned char *name_ptr;
+            STRLEN name_len;
+
+            name = newSVpv(self->key.dp->name,  strlen(self->key.dp->name));
+            name_ptr = SvPV(name, name_len);
+            for (i=0; i<name_len && name_ptr[i]>0; i++) name_ptr[i] = toLOWER(name_ptr[i]);
+            not_used = hv_store(rv_hash, "curve_name",  10, name, 0);
           }
         }
         /* =====> size */

--- a/t/pk_ecc.t
+++ b/t/pk_ecc.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 91;
+use Test::More tests => 95;
 
 use Crypt::PK::ECC qw(ecc_encrypt ecc_decrypt ecc_sign_message ecc_verify_message ecc_sign_hash ecc_verify_hash ecc_shared_secret);
 
@@ -128,6 +128,7 @@ for my $priv (qw/openssl_ec-short.pem openssl_ec-short.der/) {
   is($k->size, 32, "size $priv");
   is(uc($k->key2hash->{pub_x}), 'A01532A3C0900053DE60FBEFEFCCA58793301598D308B41E6F4E364E388C2711', "key2hash $priv");
   is(uc($k->curve2hash->{prime}), 'FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF', "curve2hash $priv");
+  is($k->key2hash->{curve_name}, "secp256r1", "EC curve_name is lowercase");
 }
 
 for my $pub (qw/openssl_ec-short.pub.pem openssl_ec-short.pub.der/) {
@@ -136,4 +137,5 @@ for my $pub (qw/openssl_ec-short.pub.pem openssl_ec-short.pub.der/) {
   ok(!$k->is_private, "is_private $pub");
   is($k->size, 32, "$pub size");
   is(uc($k->key2hash->{pub_x}), 'A01532A3C0900053DE60FBEFEFCCA58793301598D308B41E6F4E364E388C2711', "key2hash $pub");
+  is($k->key2hash->{curve_name}, "secp256r1", "EC curve_name is lowercase");
 }


### PR DESCRIPTION
Depending on how the ec key gets created or imported `key2hash()` returns the `curve_name` property either in lower- or uppercase.
The value is lowercase if the curve parameters are imported or set by the user and uppercase if the name is directly returned from libtomcrypt.

Since `generate_key()` expects the name in lowercase, we convert the value to lowercase as well.
As a sideeffect this also avoids unneccessary curve parameter lookups in `Crypt::PK::ECC::_curve_name_lookup()`.