### PR TITLE
Fixes + some EC tests

### DIFF
--- a/lib/Crypt/PK/ECC.pm
+++ b/lib/Crypt/PK/ECC.pm
@@ -396,13 +396,13 @@ sub _curve_name_lookup {
 
   return $key->{curve_name} if $key->{curve_name} && exists $curve{$key->{curve_name}};
 
-  my $A        = $key->{curve_A}        or return;
-  my $B        = $key->{curve_B}        or return;
-  my $Gx       = $key->{curve_Gx}       or return;
-  my $Gy       = $key->{curve_Gy}       or return;
-  my $order    = $key->{curve_order}    or return;
-  my $prime    = $key->{curve_prime}    or return;
-  my $cofactor = $key->{curve_cofactor} or return;
+  defined(my $A        = $key->{curve_A})        or return;
+  defined(my $B        = $key->{curve_B})        or return;
+  defined(my $Gx       = $key->{curve_Gx})       or return;
+  defined(my $Gy       = $key->{curve_Gy})       or return;
+  defined(my $order    = $key->{curve_order})    or return;
+  defined(my $prime    = $key->{curve_prime})    or return;
+  defined(my $cofactor = $key->{curve_cofactor}) or return;
   $A     =~ s/^0+//;
   $B     =~ s/^0+//;
   $Gx    =~ s/^0+//;

--- a/src/ltc/pk/ecc/ecc_export_full.c
+++ b/src/ltc/pk/ecc/ecc_export_full.c
@@ -41,6 +41,7 @@ int ecc_export_full(unsigned char *out, unsigned long *outlen, int type, ecc_key
 
   if (key->type != PK_PRIVATE && type == PK_PRIVATE)                                   return CRYPT_PK_TYPE_MISMATCH;
   if (ltc_ecc_is_valid_idx(key->idx) == 0)                                             return CRYPT_INVALID_ARG;
+  if (key->dp == NULL)                                                                 return CRYPT_INVALID_ARG;
 
   if ((err = mp_init_multi(&prime, &order, &a, &b, &gx, &gy, NULL)) != CRYPT_OK)       return err;
 


### PR DESCRIPTION
During working on the short OID export I discovered two bugs. One in `ecc_export_full`, the other in the `_curve_name_lookup` subroutine. Both fixed in the first two commits.

The third adds some ecc export+import tests. I think they would have prohibited #15.

The short OID PR will be a follow up PR.