### PR TITLE
Add ability to export ecc keys in short/oid form.

### DIFF
--- a/CryptX.xs
+++ b/CryptX.xs
@@ -186,7 +186,7 @@ ltc_ecc_set_type* _ecc_set_dp_from_SV(ltc_ecc_set_type *dp, SV *curve)
 {
   HV *h;
   SV *param, **pref;
-  SV **sv_cofactor, **sv_prime, **sv_A, **sv_B, **sv_order, **sv_Gx, **sv_Gy;
+  SV **sv_cofactor, **sv_prime, **sv_A, **sv_B, **sv_order, **sv_Gx, **sv_Gy, **sv_oid;
   int err;
   char *ch_name;
   STRLEN l_name;
@@ -200,7 +200,6 @@ ltc_ecc_set_type* _ecc_set_dp_from_SV(ltc_ecc_set_type *dp, SV *curve)
   }
   else if (SvROK(curve)) {
     param = curve;
-    ch_name = "custom";
   }
   else {
     croak("FATAL: curve has to be a string or a hashref");
@@ -232,7 +231,9 @@ ltc_ecc_set_type* _ecc_set_dp_from_SV(ltc_ecc_set_type *dp, SV *curve)
                     SvPV_nolen(*sv_Gx),
                     SvPV_nolen(*sv_Gy),
                     (unsigned long)SvUV(*sv_cofactor),
-                    ch_name );
+                    NULL, /* we intentionally don't allow setting custom names */
+                    NULL  /* we intentionally don't allow setting custom OIDs */
+                  );
   return err == CRYPT_OK ? dp : NULL;
 }
 

--- a/inc/CryptX_PK_ECC.xs.inc
+++ b/inc/CryptX_PK_ECC.xs.inc
@@ -169,7 +169,14 @@ key2hash(Crypt::PK::ECC self)
             name = newSVpv(self->key.dp->name,  strlen(self->key.dp->name));
             name_ptr = SvPV(name, name_len);
             for (i=0; i<name_len && name_ptr[i]>0; i++) name_ptr[i] = toLOWER(name_ptr[i]);
-            not_used = hv_store(rv_hash, "curve_name",  10, name, 0);
+            not_used = hv_store(rv_hash, "curve_name", 10, name, 0);
+          }
+          if (self->key.dp->oid.OIDlen > 0) {
+            int i;
+            SV *oid = newSVpv("", 0);
+            for(i = 0; i < self->key.dp->oid.OIDlen - 1; i++) sv_catpvf(oid, "%lu.", self->key.dp->oid.OID[i]);
+            sv_catpvf(oid, "%lu", self->key.dp->oid.OID[i]);
+            not_used = hv_store(rv_hash, "curve_oid", 9, oid, 0);
           }
         }
         /* =====> size */

--- a/inc/CryptX_PK_ECC.xs.inc
+++ b/inc/CryptX_PK_ECC.xs.inc
@@ -190,9 +190,19 @@ export_key_der(Crypt::PK::ECC self, char * type)
         unsigned long int out_len = 4096;
 
         RETVAL = newSVpvn(NULL, 0); /* undef */
-        if (strnEQ(type, "private", 7)) {
+        if (strnEQ(type, "private_short", 16)) {
+          rv = ecc_export_full(out, &out_len, PK_PRIVATE|PK_CURVEOID, &self->key);
+          if (rv != CRYPT_OK) croak("FATAL: ecc_export(PK_PRIVATE|PK_CURVEOID) failed: %s", error_to_string(rv));
+          RETVAL = newSVpvn((char*)out, out_len);
+        }
+        else if (strnEQ(type, "private", 7)) {
           rv = ecc_export_full(out, &out_len, PK_PRIVATE, &self->key);
           if (rv != CRYPT_OK) croak("FATAL: ecc_export(PK_PRIVATE) failed: %s", error_to_string(rv));
+          RETVAL = newSVpvn((char*)out, out_len);
+        }
+        else if (strnEQ(type, "public_short", 15)) {
+          rv = ecc_export_full(out, &out_len, PK_PUBLIC|PK_CURVEOID, &self->key);
+          if (rv != CRYPT_OK) croak("FATAL: ecc_export(PK_PUBLIC|PK_CURVEOID) failed: %s", error_to_string(rv));
           RETVAL = newSVpvn((char*)out, out_len);
         }
         else if (strnEQ(type, "public", 6)) {

--- a/lib/Crypt/PK/ECC.pm
+++ b/lib/Crypt/PK/ECC.pm
@@ -434,8 +434,8 @@ sub export_key_pem {
   my ($self, $type, $password, $cipher) = @_;
   my $key = $self->export_key_der($type||'');
   return unless $key;
-  return der_to_pem($key, "EC PRIVATE KEY", $password, $cipher) if $type eq 'private';
-  return der_to_pem($key, "PUBLIC KEY") if $type eq 'public' || $type eq 'public_compressed';
+  return der_to_pem($key, "EC PRIVATE KEY", $password, $cipher) if substr($type, 0, 7) eq 'private';
+  return der_to_pem($key, "PUBLIC KEY") if substr($type,0, 6) eq 'public';
 }
 
 sub export_key_jwk {
@@ -1027,11 +1027,25 @@ Import raw public/private key - can load data exported by L</export_key_raw>.
  #or
  my $public_der = $pk->export_key_der('public');
 
+Since CryptX-0.36 C<export_key_der> can also export keys in a format
+that does not explicitely contain curve parameters but only curve OID.
+
+ my $private_der = $pk->export_key_der('private_short');
+ #or
+ my $public_der = $pk->export_key_der('public_short');
+
 =head2 export_key_pem
 
  my $private_pem = $pk->export_key_pem('private');
  #or
  my $public_pem = $pk->export_key_pem('public');
+
+Since CryptX-0.36 C<export_key_pem> can also export keys in a format
+that does not explicitely contain curve parameters but only curve OID.
+
+ my $private_pem = $pk->export_key_pem('private_short');
+ #or
+ my $public_pem = $pk->export_key_pem('public_short');
 
 Support for password protected PEM keys
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -74,8 +74,9 @@ ltc/pk/dsa/dsa_decrypt_key.o ltc/pk/dsa/dsa_encrypt_key.o ltc/pk/dsa/dsa_export.
 ltc/pk/dsa/dsa_import.o ltc/pk/dsa/dsa_import_hex.o ltc/pk/dsa/dsa_make_key.o ltc/pk/dsa/dsa_shared_secret.o \
 ltc/pk/dsa/dsa_sign_hash.o ltc/pk/dsa/dsa_verify_hash.o ltc/pk/dsa/dsa_verify_key.o ltc/pk/ecc/ecc.o \
 ltc/pk/ecc/ecc_ansi_x963_export.o ltc/pk/ecc/ecc_ansi_x963_import.o ltc/pk/ecc/ecc_decrypt_key.o \
-ltc/pk/ecc/ecc_dp_clear.o ltc/pk/ecc/ecc_dp_from_oid.o ltc/pk/ecc/ecc_dp_from_params.o ltc/pk/ecc/ecc_dp_init.o \
-ltc/pk/ecc/ecc_dp_set.o ltc/pk/ecc/ecc_encrypt_key.o ltc/pk/ecc/ecc_export.o ltc/pk/ecc/ecc_export_full.o \
+ltc/pk/ecc/ecc_dp_clear.o ltc/pk/ecc/ecc_dp_fill_from_sets.o ltc/pk/ecc/ecc_dp_from_oid.o \
+ltc/pk/ecc/ecc_dp_from_params.o ltc/pk/ecc/ecc_dp_init.o ltc/pk/ecc/ecc_dp_set.o \
+ltc/pk/ecc/ecc_encrypt_key.o ltc/pk/ecc/ecc_export.o ltc/pk/ecc/ecc_export_full.o \
 ltc/pk/ecc/ecc_export_raw.o ltc/pk/ecc/ecc_free.o ltc/pk/ecc/ecc_get_size.o ltc/pk/ecc/ecc_import.o \
 ltc/pk/ecc/ecc_import_full.o ltc/pk/ecc/ecc_import_pkcs8.o ltc/pk/ecc/ecc_import_raw.o \
 ltc/pk/ecc/ecc_make_key.o ltc/pk/ecc/ecc_shared_secret.o ltc/pk/ecc/ecc_sign_hash.o ltc/pk/ecc/ecc_sizes.o \

--- a/src/Makefile.nmake
+++ b/src/Makefile.nmake
@@ -74,8 +74,9 @@ ltc/pk/dsa/dsa_decrypt_key.obj ltc/pk/dsa/dsa_encrypt_key.obj ltc/pk/dsa/dsa_exp
 ltc/pk/dsa/dsa_import.obj ltc/pk/dsa/dsa_import_hex.obj ltc/pk/dsa/dsa_make_key.obj ltc/pk/dsa/dsa_shared_secret.obj \
 ltc/pk/dsa/dsa_sign_hash.obj ltc/pk/dsa/dsa_verify_hash.obj ltc/pk/dsa/dsa_verify_key.obj ltc/pk/ecc/ecc.obj \
 ltc/pk/ecc/ecc_ansi_x963_export.obj ltc/pk/ecc/ecc_ansi_x963_import.obj ltc/pk/ecc/ecc_decrypt_key.obj \
-ltc/pk/ecc/ecc_dp_clear.obj ltc/pk/ecc/ecc_dp_from_oid.obj ltc/pk/ecc/ecc_dp_from_params.obj ltc/pk/ecc/ecc_dp_init.obj \
-ltc/pk/ecc/ecc_dp_set.obj ltc/pk/ecc/ecc_encrypt_key.obj ltc/pk/ecc/ecc_export.obj ltc/pk/ecc/ecc_export_full.obj \
+ltc/pk/ecc/ecc_dp_clear.obj ltc/pk/ecc/ecc_dp_fill_from_sets.obj ltc/pk/ecc/ecc_dp_from_oid.obj \
+ltc/pk/ecc/ecc_dp_from_params.obj ltc/pk/ecc/ecc_dp_init.obj ltc/pk/ecc/ecc_dp_set.obj \
+ltc/pk/ecc/ecc_encrypt_key.obj ltc/pk/ecc/ecc_export.obj ltc/pk/ecc/ecc_export_full.obj \
 ltc/pk/ecc/ecc_export_raw.obj ltc/pk/ecc/ecc_free.obj ltc/pk/ecc/ecc_get_size.obj ltc/pk/ecc/ecc_import.obj \
 ltc/pk/ecc/ecc_import_full.obj ltc/pk/ecc/ecc_import_pkcs8.obj ltc/pk/ecc/ecc_import_raw.obj \
 ltc/pk/ecc/ecc_make_key.obj ltc/pk/ecc/ecc_shared_secret.obj ltc/pk/ecc/ecc_sign_hash.obj ltc/pk/ecc/ecc_sizes.obj \

--- a/src/ltc/headers/tomcrypt_pk.h
+++ b/src/ltc/headers/tomcrypt_pk.h
@@ -299,7 +299,7 @@ void ecc_sizes(int *low, int *high);
 int  ecc_get_size(ecc_key *key);
 
 int ecc_dp_init(ltc_ecc_set_type *dp);
-int ecc_dp_set(ltc_ecc_set_type *dp, char *ch_prime, char *ch_A, char *ch_B, char *ch_order, char *ch_Gx, char *ch_Gy, unsigned long cofactor, char *ch_name);
+int ecc_dp_set(ltc_ecc_set_type *dp, char *ch_prime, char *ch_A, char *ch_B, char *ch_order, char *ch_Gx, char *ch_Gy, unsigned long cofactor, char *ch_name, char *oid);
 int ecc_dp_set_bn(ltc_ecc_set_type *dp, void *a, void *b, void *prime, void *order, void *gx, void *gy, unsigned long cofactor);
 int ecc_dp_set_by_oid(ltc_ecc_set_type *dp, unsigned long *oid, unsigned long oidsize);
 int ecc_dp_fill_from_sets(ltc_ecc_set_type *dp);

--- a/src/ltc/headers/tomcrypt_pk.h
+++ b/src/ltc/headers/tomcrypt_pk.h
@@ -3,7 +3,8 @@
 enum {
    PK_PUBLIC=0,
    PK_PRIVATE=1,
-   PK_PUBLIC_COMPRESSED=2  /* used only when exporting public ECC key */
+   PK_PUBLIC_COMPRESSED=2, /* used only when exporting public ECC key */
+   PK_CURVEOID=4           /* used only when exporting public ECC key */
 };
 
 /* Indicates standard output formats that can be read e.g. by OpenSSL or GnuTLS */
@@ -302,7 +303,6 @@ int ecc_dp_set(ltc_ecc_set_type *dp, char *ch_prime, char *ch_A, char *ch_B, cha
 int ecc_dp_set_bn(ltc_ecc_set_type *dp, void *a, void *b, void *prime, void *order, void *gx, void *gy, unsigned long cofactor);
 int ecc_dp_set_by_oid(ltc_ecc_set_type *dp, unsigned long *oid, unsigned long oidsize);
 int ecc_dp_clear(ltc_ecc_set_type *dp);
-
 
 int  ecc_make_key(prng_state *prng, int wprng, int keysize, ecc_key *key);
 int  ecc_make_key_ex(prng_state *prng, int wprng, ecc_key *key, const ltc_ecc_set_type *dp);

--- a/src/ltc/headers/tomcrypt_pk.h
+++ b/src/ltc/headers/tomcrypt_pk.h
@@ -302,6 +302,7 @@ int ecc_dp_init(ltc_ecc_set_type *dp);
 int ecc_dp_set(ltc_ecc_set_type *dp, char *ch_prime, char *ch_A, char *ch_B, char *ch_order, char *ch_Gx, char *ch_Gy, unsigned long cofactor, char *ch_name);
 int ecc_dp_set_bn(ltc_ecc_set_type *dp, void *a, void *b, void *prime, void *order, void *gx, void *gy, unsigned long cofactor);
 int ecc_dp_set_by_oid(ltc_ecc_set_type *dp, unsigned long *oid, unsigned long oidsize);
+int ecc_dp_fill_from_sets(ltc_ecc_set_type *dp);
 int ecc_dp_clear(ltc_ecc_set_type *dp);
 
 int  ecc_make_key(prng_state *prng, int wprng, int keysize, ecc_key *key);

--- a/src/ltc/pk/ecc/ecc_dp_clear.c
+++ b/src/ltc/pk/ecc/ecc_dp_clear.c
@@ -27,7 +27,8 @@ int ecc_dp_clear(ltc_ecc_set_type *dp)
   if (dp->order != NULL) { XFREE(dp->order); dp->order = NULL; }
   if (dp->Gx    != NULL) { XFREE(dp->Gx   ); dp->Gx    = NULL; }
   if (dp->Gy    != NULL) { XFREE(dp->Gy   ); dp->Gy    = NULL; }
-  dp->cofactor = 0;
+  dp->cofactor   = 0;
+  dp->oid.OIDlen = 0;
 
   return CRYPT_OK;
 }

--- a/src/ltc/pk/ecc/ecc_dp_fill_from_sets.c
+++ b/src/ltc/pk/ecc/ecc_dp_fill_from_sets.c
@@ -1,0 +1,54 @@
+/* LibTomCrypt, modular cryptographic library -- Tom St Denis
+ *
+ * LibTomCrypt is a library that provides various cryptographic
+ * algorithms in a highly modular and flexible manner.
+ *
+ * The library is free for all purposes without any express
+ * guarantee it works.
+ *
+ */
+
+#include "tomcrypt.h"
+
+#ifdef LTC_MECC
+
+/* search known curve by curve parameters and fill in missing parameters into dp
+ * we assume every parameter has the same case (usually uppercase) and no leading zeros
+ */
+int ecc_dp_fill_from_sets(ltc_ecc_set_type *dp)
+{
+  ltc_ecc_set_type params;
+  int x;
+
+  if (!dp)                return CRYPT_INVALID_ARG;
+  if (dp->oid.OIDlen > 0) return CRYPT_OK;
+  if (!dp->prime || !dp->A || !dp->B || !dp->order || !dp->Gx || !dp->Gy || dp->cofactor == 0) return CRYPT_INVALID_ARG;
+
+  for (x = 0; ltc_ecc_sets[x].size != 0; x++) {
+    if (XSTRCMP(ltc_ecc_sets[x].prime, dp->prime) == 0 &&
+        XSTRCMP(ltc_ecc_sets[x].A,     dp->A)     == 0 &&
+        XSTRCMP(ltc_ecc_sets[x].B,     dp->B)     == 0 &&
+        XSTRCMP(ltc_ecc_sets[x].order, dp->order) == 0 &&
+        XSTRCMP(ltc_ecc_sets[x].Gx,    dp->Gx)    == 0 &&
+        XSTRCMP(ltc_ecc_sets[x].Gy,    dp->Gy)    == 0 &&
+        ltc_ecc_sets[x].cofactor == dp->cofactor) {
+
+      params = ltc_ecc_sets[x];
+
+      /* copy oid */
+      dp->oid.OIDlen = params.oid.OIDlen;
+      XMEMCPY(dp->oid.OID, params.oid.OID, dp->oid.OIDlen * sizeof(dp->oid.OID[0]));
+
+      /* copy name */
+      if (dp->name != NULL) XFREE(dp->name);
+      if ((dp->name = XMALLOC(1+strlen(params.name))) == NULL) return CRYPT_MEM;
+      strcpy(dp->name, params.name);
+
+      return CRYPT_OK;
+    }
+  }
+
+  return CRYPT_INVALID_ARG;
+}
+
+#endif

--- a/src/ltc/pk/ecc/ecc_dp_from_oid.c
+++ b/src/ltc/pk/ecc/ecc_dp_from_oid.c
@@ -61,6 +61,9 @@ int ecc_dp_set_by_oid(ltc_ecc_set_type *dp, unsigned long *oid, unsigned long oi
   len = (unsigned long)strlen(ltc_ecc_sets[i].name);
   if ((dp->name = XMALLOC(1+len)) == NULL)      goto cleanup7;
   strncpy(dp->name, ltc_ecc_sets[i].name, 1+len);
+  /* oid */
+  dp->oid.OIDlen = ltc_ecc_sets[i].oid.OIDlen;
+  XMEMCPY(dp->oid.OID, ltc_ecc_sets[i].oid.OID, dp->oid.OIDlen * sizeof(dp->oid.OID[0]));
   /* done - success */
   return CRYPT_OK;
 

--- a/src/ltc/pk/ecc/ecc_dp_from_params.c
+++ b/src/ltc/pk/ecc/ecc_dp_from_params.c
@@ -55,9 +55,14 @@ int ecc_dp_set_bn(ltc_ecc_set_type *dp, void *a, void *b, void *prime, void *ord
   /* cofactor & size */
   dp->cofactor = cofactor;
   dp->size = mp_unsigned_bin_size(prime);
-  /* name */
-  if ((dp->name = XMALLOC(7)) == NULL)          goto cleanup7;
-  strcpy(dp->name, "custom");  /* XXX-TODO check this */
+  /* see if we can fill in the missing parameters from known curves */
+  if ((ecc_dp_fill_from_sets(dp)) != CRYPT_OK) {
+    /* custom name */
+    if ((dp->name = XMALLOC(7)) == NULL)        goto cleanup7;
+    strcpy(dp->name, "custom");  /* XXX-TODO check this */
+    /* no oid */
+    dp->oid.OIDlen = 0;
+  }
   /* done - success */
   return CRYPT_OK;
 

--- a/src/ltc/pk/ecc/ecc_dp_set.c
+++ b/src/ltc/pk/ecc/ecc_dp_set.c
@@ -13,6 +13,7 @@
  */
 
 #include "tomcrypt.h"
+#include <errno.h>
 
 #ifdef LTC_MECC
 
@@ -22,7 +23,6 @@ int ecc_dp_set(ltc_ecc_set_type *dp, char *ch_prime, char *ch_A, char *ch_B, cha
 
   if (!dp || !ch_prime || !ch_A || !ch_B || !ch_order || !ch_Gx || !ch_Gy || cofactor==0) return CRYPT_INVALID_ARG;
 
-  l_name  = (unsigned long)strlen(ch_name);
   l_prime = (unsigned long)strlen(ch_prime);
   l_A     = (unsigned long)strlen(ch_A);
   l_B     = (unsigned long)strlen(ch_B);
@@ -48,13 +48,31 @@ int ecc_dp_set(ltc_ecc_set_type *dp, char *ch_prime, char *ch_A, char *ch_B, cha
   if (dp->Gx    != NULL) { XFREE(dp->Gx   ); dp->Gx    = NULL; }
   if (dp->Gy    != NULL) { XFREE(dp->Gy   ); dp->Gy    = NULL; }
 
-  dp->name  = XMALLOC(1+l_name);  strncpy(dp->name,  ch_name,  1+l_name);
   dp->prime = XMALLOC(1+l_prime); strncpy(dp->prime, ch_prime, 1+l_prime);
   dp->A     = XMALLOC(1+l_A);     strncpy(dp->A,     ch_A,     1+l_A);
   dp->B     = XMALLOC(1+l_B);     strncpy(dp->B,     ch_B,     1+l_B);
   dp->order = XMALLOC(1+l_order); strncpy(dp->order, ch_order, 1+l_order);
   dp->Gx    = XMALLOC(1+l_Gx);    strncpy(dp->Gx,    ch_Gx,    1+l_Gx);
   dp->Gy    = XMALLOC(1+l_Gy);    strncpy(dp->Gy,    ch_Gy,    1+l_Gy);
+
+  /* optional parameters */
+  if (ch_name == NULL) {
+    (void)ecc_dp_fill_from_sets(dp);
+  }
+  else {
+    if (ch_name != NULL) {
+      l_name   = (unsigned long)strlen(ch_name);
+      dp->name = XMALLOC(1+l_name);
+      strncpy(dp->name, ch_name, 1+l_name);
+    }
+  }
+
+  /* in case the parameters are really custom (unlikely) */
+  if (dp->name == NULL) {
+    dp->name = XMALLOC(7);
+    strcpy(dp->name, "custom");
+    dp->oid.OIDlen = 0;
+  }
 
   return CRYPT_OK;
 }

--- a/t/pk_ecc.t
+++ b/t/pk_ecc.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 119;
+use Test::More tests => 121;
 
 use Crypt::PK::ECC qw(ecc_encrypt ecc_decrypt ecc_sign_message ecc_verify_message ecc_sign_hash ecc_verify_hash ecc_shared_secret);
 
@@ -194,11 +194,13 @@ for my $pub (qw/openssl_ec-short.pub.pem openssl_ec-short.pub.der/) {
   $k = Crypt::PK::ECC->new;
   ok($k->generate_key($params), "generate_key hash params");
   is($k->key2hash->{curve_name}, 'secp384r1',    "key2hash curve_name");
+  is($k->key2hash->{curve_oid},  $params->{oid}, "key2hash curve_oid");
   ok($k->export_key_der('private_short'), "export_key_der auto oid");
 
   $k = Crypt::PK::ECC->new;
   ok($k->generate_key({ %$params, A => '0' }), "generate_key invalid auto oid");
   is($k->key2hash->{curve_name}, 'custom', "key2hash custom curve_name");
+  ok(!exists($k->key2hash->{curve_oid}), "key2hash curve_oid doesn't exist");
   eval { $k->export_key_der('private_short'); };
   ok($@, "export_key_der invalid auto oid");
 }

--- a/t/pk_ecc.t
+++ b/t/pk_ecc.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 108;
+use Test::More tests => 119;
 
 use Crypt::PK::ECC qw(ecc_encrypt ecc_decrypt ecc_sign_message ecc_verify_message ecc_sign_hash ecc_verify_hash ecc_shared_secret);
 
@@ -137,6 +137,8 @@ sub read_file {
   #ok($k->export_key_pem('public'), 'export_key_pem pub');
   ok($k->export_key_der('private'), 'export_key_der pri');
   ok($k->export_key_der('public'), 'export_key_der pub');
+  ok($k->export_key_der('private_short'), 'export_key_der pri_short');
+  ok($k->export_key_der('public_short'), 'export_key_der pub_short');
 }
 
 {
@@ -158,22 +160,28 @@ sub read_file {
 }
 
 for my $priv (qw/openssl_ec-short.pem openssl_ec-short.der/) {
-  my $k = Crypt::PK::ECC->new("t/data/$priv");
+  my $f = "t/data/$priv";
+  my $k = Crypt::PK::ECC->new($f);
   ok($k, "load $priv");
   ok($k->is_private, "is_private $priv");
   is($k->size, 32, "size $priv");
   is(uc($k->key2hash->{pub_x}), 'A01532A3C0900053DE60FBEFEFCCA58793301598D308B41E6F4E364E388C2711', "key2hash $priv");
   is(uc($k->curve2hash->{prime}), 'FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF', "curve2hash $priv");
   is($k->key2hash->{curve_name}, "secp256r1", "EC curve_name is lowercase");
+  is($k->export_key_der('private_short'), read_file($f), 'export_key_der private_oid') if (substr($priv, -3) eq "der");
+  is($k->export_key_pem('private_short'), read_file($f), 'export_key_pem private_oid') if (substr($priv, -3) eq "pem");
 }
 
 for my $pub (qw/openssl_ec-short.pub.pem openssl_ec-short.pub.der/) {
-  my $k = Crypt::PK::ECC->new("t/data/$pub");
+  my $f = "t/data/$pub";
+  my $k = Crypt::PK::ECC->new($f);
   ok($k, "load $pub");
   ok(!$k->is_private, "is_private $pub");
   is($k->size, 32, "$pub size");
   is(uc($k->key2hash->{pub_x}), 'A01532A3C0900053DE60FBEFEFCCA58793301598D308B41E6F4E364E388C2711', "key2hash $pub");
   is($k->key2hash->{curve_name}, "secp256r1", "EC curve_name is lowercase");
+  is($k->export_key_der('public_short'), read_file($f), 'export_key_der public_short') if (substr($pub, -3) eq "der");
+  is($k->export_key_pem('public_short'), read_file($f), 'export_key_pem public_short') if (substr($pub, -3) eq "pem");
 }
 
 {
@@ -181,6 +189,16 @@ for my $pub (qw/openssl_ec-short.pub.pem openssl_ec-short.pub.der/) {
   eval { $k->export_key_pem('public'); };
   ok($@, 'key not generated');
 
+  # known curves lookup
   my $params = $Crypt::PK::ECC::curve{secp384r1};
+  $k = Crypt::PK::ECC->new;
   ok($k->generate_key($params), "generate_key hash params");
+  is($k->key2hash->{curve_name}, 'secp384r1',    "key2hash curve_name");
+  ok($k->export_key_der('private_short'), "export_key_der auto oid");
+
+  $k = Crypt::PK::ECC->new;
+  ok($k->generate_key({ %$params, A => '0' }), "generate_key invalid auto oid");
+  is($k->key2hash->{curve_name}, 'custom', "key2hash custom curve_name");
+  eval { $k->export_key_der('private_short'); };
+  ok($@, "export_key_der invalid auto oid");
 }


### PR DESCRIPTION
As already discussed in #13 this adds the new `PK_CURVEOID` flag + integration into perl-CryptX. I've split the commits for libtomcrypt so you can better merge them to upstream.

Regarding commit cb7369a6d2ac315b8c1d9c7be379f8c251351710: I'm not sure if we really should allow setting the OID as importing a custom OID again definitely won't work. If we abandon this commit, we should also abandon the last one.