### PR TITLE
accept CFLAGS and CPPFLAGS from the environment

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,7 @@ my @myobjs = map { s|.c$|$Config{obj_ext}|; $_ } grep { $_ !~ m|^src/ltc/\.*tab\
 );
 my $myextlib = "src/liballinone$Config{lib_ext}";
 my $mycflags = "$Config{ccflags} $Config{cccdlflags} $Config{optimize}";
+$mycflags .= " $ENV{CFLAGS}" if $ENV{CFLAGS};
 
 #FIX: gcc with -flto is a trouble maker see https://github.com/DCIT/perl-CryptX/issues/32
 $mycflags =~ s/-flto\b//g;

--- a/src/Makefile
+++ b/src/Makefile
@@ -170,4 +170,4 @@ clean:
 .SUFFIXES: .o .c
 
 .c$(OBJ_EXT):
-	$(CC) -Iltm -Iltc/headers -DLTC_SOURCE -DLTC_NO_TEST -DLTC_NO_PROTOTYPES -DLTM_DESC $(CFLAGS) -c $< -o $@
+	$(CC) -Iltm -Iltc/headers -DLTC_SOURCE -DLTC_NO_TEST -DLTC_NO_PROTOTYPES -DLTM_DESC $(CFLAGS) $(CPPFLAGS) -c $< -o $@


### PR DESCRIPTION

In Debian we are currently applying the following patch to CryptX.
We thought you might be interested in it too.

    Description: accept CFLAGS and CPPFLAGS from the environment
     This is particularly useful for Debian, where the build system puts
     various hardening flags in CFLAGS and CPPFLAGS
    Author: Damyan Ivanov <dmn@debian.org>

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libcryptx-perl.git/plain/debian/patches/compilation-flags.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
