### PR TITLE
Fix typos in POD

### DIFF
--- a/lib/Crypt/Cipher.pm
+++ b/lib/Crypt/Cipher.pm
@@ -129,7 +129,7 @@ Crypt::Cipher - Generic interface to cipher functions
 
 =head1 DESCRIPTION
 
-Provides an interface to various symetric cipher algorithms.
+Provides an interface to various symmetric cipher algorithms.
 
 B<BEWARE:> This module implements just elementary "one-block-(en|de)cryption" operation - if you want to
 encrypt/decrypt generic data you have to use some of the cipher block modes - check for example
@@ -150,7 +150,7 @@ Constructor, returns a reference to the cipher object.
  #                simply any <NAME> for which there exists Crypt::Cipher::<NAME>
  # $key = binary key (keysize should comply with selected cipher requirements)
 
- ## some of the ciphers (e.g. MULTI2, RC5, SAFER) allows to set number of rounds
+ ## some of the ciphers (e.g. MULTI2, RC5, SAFER) allow one to set number of rounds
  $d = Crypt::Cipher->new('MULTI2', $key, $rounds);
  # $rounds = positive integer (should comply with selected cipher requirements)
 
@@ -202,7 +202,7 @@ Returns block size (in bytes) for given cipher.
 
 =head2 default_rounds
 
-Returns default number of rounds for given cipher. NOTE: only some cipher (e.g. MULTI2, RC5, SAFER) allows to set number of rounds via new().
+Returns default number of rounds for given cipher. NOTE: only some ciphers (e.g. MULTI2, RC5, SAFER) allow one to set number of rounds via new().
 
  $d->default_rounds;
  #or

--- a/lib/Crypt/Cipher/AES.pm
+++ b/lib/Crypt/Cipher/AES.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::AES - Symetric cipher AES (aka Rijndael), key size: 128/192/256 bits (Crypt::CBC compliant)
+Crypt::Cipher::AES - Symmetric cipher AES (aka Rijndael), key size: 128/192/256 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Anubis.pm
+++ b/lib/Crypt/Cipher/Anubis.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Anubis - Symetric cipher Anubis, key size: 128-320 bits (Crypt::CBC compliant)
+Crypt::Cipher::Anubis - Symmetric cipher Anubis, key size: 128-320 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Blowfish.pm
+++ b/lib/Crypt/Cipher/Blowfish.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Blowfish - Symetric cipher Blowfish, key size: 64-448 bits (Crypt::CBC compliant)
+Crypt::Cipher::Blowfish - Symmetric cipher Blowfish, key size: 64-448 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/CAST5.pm
+++ b/lib/Crypt/Cipher/CAST5.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::CAST5 - Symetric cipher CAST5 (aka CAST-128), key size: 40-128 bits (Crypt::CBC compliant)
+Crypt::Cipher::CAST5 - Symmetric cipher CAST5 (aka CAST-128), key size: 40-128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Camellia.pm
+++ b/lib/Crypt/Cipher/Camellia.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Camellia - Symetric cipher Camellia, key size: 128/192/256 bits (Crypt::CBC compliant)
+Crypt::Cipher::Camellia - Symmetric cipher Camellia, key size: 128/192/256 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/DES.pm
+++ b/lib/Crypt/Cipher/DES.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::DES - Symetric cipher DES, key size: 64[56] bits (Crypt::CBC compliant)
+Crypt::Cipher::DES - Symmetric cipher DES, key size: 64[56] bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/DES_EDE.pm
+++ b/lib/Crypt/Cipher/DES_EDE.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::DES_EDE - Symetric cipher DES_EDE (aka Tripple-DES, 3DES), key size: 192[168] bits (Crypt::CBC compliant)
+Crypt::Cipher::DES_EDE - Symmetric cipher DES_EDE (aka Tripple-DES, 3DES), key size: 192[168] bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/IDEA.pm
+++ b/lib/Crypt/Cipher/IDEA.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::IDEA - Symetric cipher IDEA, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::IDEA - Symmetric cipher IDEA, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/KASUMI.pm
+++ b/lib/Crypt/Cipher/KASUMI.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::KASUMI - Symetric cipher KASUMI, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::KASUMI - Symmetric cipher KASUMI, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Khazad.pm
+++ b/lib/Crypt/Cipher/Khazad.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Khazad - Symetric cipher Khazad, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::Khazad - Symmetric cipher Khazad, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/MULTI2.pm
+++ b/lib/Crypt/Cipher/MULTI2.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::MULTI2 - Symetric cipher MULTI2, key size: 320 bits (Crypt::CBC compliant)
+Crypt::Cipher::MULTI2 - Symmetric cipher MULTI2, key size: 320 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Noekeon.pm
+++ b/lib/Crypt/Cipher/Noekeon.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Noekeon - Symetric cipher Noekeon, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::Noekeon - Symmetric cipher Noekeon, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/RC2.pm
+++ b/lib/Crypt/Cipher/RC2.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::RC2 - Symetric cipher RC2, key size: 40-1024 bits (Crypt::CBC compliant)
+Crypt::Cipher::RC2 - Symmetric cipher RC2, key size: 40-1024 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/RC5.pm
+++ b/lib/Crypt/Cipher/RC5.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::RC5 - Symetric cipher RC5, key size: 64-1024 bits (Crypt::CBC compliant)
+Crypt::Cipher::RC5 - Symmetric cipher RC5, key size: 64-1024 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/RC6.pm
+++ b/lib/Crypt/Cipher/RC6.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::RC6 - Symetric cipher RC6, key size: 64-1024 bits (Crypt::CBC compliant)
+Crypt::Cipher::RC6 - Symmetric cipher RC6, key size: 64-1024 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/SAFERP.pm
+++ b/lib/Crypt/Cipher/SAFERP.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::SAFERP - Symetric cipher SAFER+, key size: 128/192/256 bits (Crypt::CBC compliant)
+Crypt::Cipher::SAFERP - Symmetric cipher SAFER+, key size: 128/192/256 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/SAFER_K128.pm
+++ b/lib/Crypt/Cipher/SAFER_K128.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::SAFER_K128 - Symetric cipher SAFER_K128, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::SAFER_K128 - Symmetric cipher SAFER_K128, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/SAFER_K64.pm
+++ b/lib/Crypt/Cipher/SAFER_K64.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::SAFER_K64 - Symetric cipher SAFER_K64, key size: 64 bits (Crypt::CBC compliant)
+Crypt::Cipher::SAFER_K64 - Symmetric cipher SAFER_K64, key size: 64 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/SAFER_SK128.pm
+++ b/lib/Crypt/Cipher/SAFER_SK128.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::SAFER_SK128 - Symetric cipher SAFER_SK128, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::SAFER_SK128 - Symmetric cipher SAFER_SK128, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/SAFER_SK64.pm
+++ b/lib/Crypt/Cipher/SAFER_SK64.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::SAFER_SK64 - Symetric cipher SAFER_SK64, key size: 64 bits (Crypt::CBC compliant)
+Crypt::Cipher::SAFER_SK64 - Symmetric cipher SAFER_SK64, key size: 64 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/SEED.pm
+++ b/lib/Crypt/Cipher/SEED.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::SEED - Symetric cipher SEED, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::SEED - Symmetric cipher SEED, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Serpent.pm
+++ b/lib/Crypt/Cipher/Serpent.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Serpent - Symetric cipher Serpent, key size: 128/192/256 bits (Crypt::CBC compliant)
+Crypt::Cipher::Serpent - Symmetric cipher Serpent, key size: 128/192/256 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Skipjack.pm
+++ b/lib/Crypt/Cipher/Skipjack.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Skipjack - Symetric cipher Skipjack, key size: 80 bits (Crypt::CBC compliant)
+Crypt::Cipher::Skipjack - Symmetric cipher Skipjack, key size: 80 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/Twofish.pm
+++ b/lib/Crypt/Cipher/Twofish.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::Twofish - Symetric cipher Twofish, key size: 128/192/256 bits (Crypt::CBC compliant)
+Crypt::Cipher::Twofish - Symmetric cipher Twofish, key size: 128/192/256 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Cipher/XTEA.pm
+++ b/lib/Crypt/Cipher/XTEA.pm
@@ -21,7 +21,7 @@ sub default_rounds { Crypt::Cipher::default_rounds(__PACKAGE__) }
 
 =head1 NAME
 
-Crypt::Cipher::XTEA - Symetric cipher XTEA, key size: 128 bits (Crypt::CBC compliant)
+Crypt::Cipher::XTEA - Symmetric cipher XTEA, key size: 128 bits (Crypt::CBC compliant)
 
 =head1 SYNOPSIS
 

--- a/lib/Crypt/Digest.pm
+++ b/lib/Crypt/Digest.pm
@@ -176,7 +176,7 @@ Or all of them at once:
 
 =head1 FUNCTIONS
 
-Please note that all functions take as its first argument the algoritm name, supported values are:
+Please note that all functions take as its first argument the algorithm name, supported values are:
 
  'CHAES', 'MD2', 'MD4', 'MD5', 'RIPEMD128', 'RIPEMD160',
  'RIPEMD256', 'RIPEMD320', 'SHA1', 'SHA224', 'SHA256',

--- a/lib/Crypt/PK/ECC.pm
+++ b/lib/Crypt/PK/ECC.pm
@@ -1029,7 +1029,7 @@ Import raw public/private key - can load data exported by L</export_key_raw>.
  my $public_der = $pk->export_key_der('public');
 
 Since CryptX-0.36 C<export_key_der> can also export keys in a format
-that does not explicitely contain curve parameters but only curve OID.
+that does not explicitly contain curve parameters but only curve OID.
 
  my $private_der = $pk->export_key_der('private_short');
  #or
@@ -1042,7 +1042,7 @@ that does not explicitely contain curve parameters but only curve OID.
  my $public_pem = $pk->export_key_pem('public');
 
 Since CryptX-0.36 C<export_key_pem> can also export keys in a format
-that does not explicitely contain curve parameters but only curve OID.
+that does not explicitly contain curve parameters but only curve OID.
 
  my $private_pem = $pk->export_key_pem('private_short');
  #or


### PR DESCRIPTION

In Debian we are currently applying the following patch to CryptX.
We thought you might be interested in it too.

    Description: Fix typos in POD
    Author: Lucas Kanashiro <kanashiro@debian.org>
    Last-Updated: 2017-06-25

Most of the typos are Symetrical -> Symmetrical, but there a couple of others.

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libcryptx-perl.git/plain/debian/patches/001_fix-typos.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
