### PR TITLE
Fix building on HP-UX 11.11 / PA-RISC

### DIFF
--- a/src/ltm/tommath.h
+++ b/src/ltm/tommath.h
@@ -35,7 +35,7 @@ extern "C" {
     defined(__ia64) || defined(__ia64__) || defined(__itanium__) || defined(_M_IA64) || \
     defined(__LP64__) || defined(_LP64) || defined(__64BIT__)
 #   if !(defined(MP_32BIT) || defined(MP_16BIT) || defined(MP_8BIT))
-#      if defined(__GNUC__)
+#      if defined(__GNUC__) && !defined(__hppa)
 /* we support 128bit integers only via: __attribute__((mode(TI))) */
 #         define MP_64BIT
 #      else


### PR DESCRIPTION
```
$ perl -v
This is perl 5, version 28, subversion 2 (v5.28.2) built for PA-RISC2.0-thread-multi-LP64
```
```
$ perl Makefile.PL
Checking if your kit is complete...
Looks good
Generating a Unix-style Makefile
Writing Makefile for CryptX
Writing MYMETA.yml and MYMETA.json
```
```
$ make
:
:
gcc64 -Iltm -Iltc/headers -DLTC_SOURCE -DLTC_NO_TEST -DLTC_NO_PROTOTYPES -DLTM_DESC -D_POSIX_C_SOURCE=199506L -D_REENTRANT -mpa-risc-2-0 -fPIC -D_HPUX_SOURCE -fwrapv -fno-strict-aliasing -pipe -I/usr/local/pa20_64/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -fPIC -g -O -DARGTYPE=4 -c ltc/math/ltm_desc.c -o ltc/math/ltm_desc.o
In file included from ltc/math/ltm_desc.c:15:0:
ltm/tommath.h:74:1: error: unable to emulate 'TI'
make[1]: *** [ltc/math/ltm_desc.o] Error 1
make[1]: Leaving directory `/data/cpan-build/CryptX-0.063-0/src'
make: *** [src/liballinone.a] Error 2
```
```
$ gcc64 --version
gcc64 (GCC) 4.6.1
Copyright (C) 2011 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
```
$ perl -V:cppsymbols
cppsymbols='_FILE_OFFSET_BITS=64 _HPUX_SOURCE=1 _LARGEFILE_SOURCE=1 _LFS64_LARGEFILE=1 _LFS_LARGEFILE=1 _LP64=1 _PA_RISC2_0=1 _POSIX_C_SOURCE=199506L _PROTOTYPES= _REENTRANT=1 _XOPEN_SOURCE_EXTENDED=1 _XPG4= _XPG4_EXTENDED= __BYTE_ORDER__=4321 __ELF__=1 __GNUC_MINOR__=6 __GNUC__=4 __LP64__=1 __PIC__=2 __STDC_EXT__=1 __STDC__=1 __hp9000s700=1 __hp9000s700__=1 __hp9000s800=1 __hp9000s800__=1 __hppa=1 __hppa__=1 __hpux=1 __hpux__=1 __pic__=2 __unix=1 __unix__=1';
```