### PR TITLE
Remove -flto=auto

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,9 @@ else {
   $mycflags .= " $ENV{CPPFLAGS}" if $ENV{CPPFLAGS};
 
   #FIX: gcc with -flto is a trouble maker see https://github.com/DCIT/perl-CryptX/issues/32
-  $mycflags =~ s/-flto\b//g;
+  # EXTRA: -flto=auto gets added by some compilers -- we should also remove the the
+  # =auto part, or it will end up in the gcc compilation line and break.
+  $mycflags =~ s/-flto(?:=auto)\b//g;
 
   #FIX: avoid -Wwrite-strings -Wcast-qual -pedantic -pedantic-errors -ansi -std=c89
   $mycflags =~ s/-pedantic\b//g;


### PR DESCRIPTION
`Makefile.PL` is removing `-flto`, and if the original line had `-flto=auto`, it then causes compilation to file.

Reproducible on a fedora docker image:
```
;  dnf check-update
;  dnf install -y perl curl
;  curl -L https://cpanmin.us | perl - App::cpanminus
;  cpanm -v CryptX
```

Which throws this error:
```
...
cd src && make ARFLAGS="cr" RANLIB=":" AR="ar" CC="gcc" LIB_EXT=.a OBJ_EXT=.o CFLAGS="-D_REENTRANT -D_GNU_SOURCE -O2 =auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC   -g"
make[1]: Entering directory '/root/.cpanm/work/1606752895.2028/CryptX-0.069/src'
gcc -Iltm -Iltc/headers -DLTC_SOURCE -DLTC_NO_TEST -DLTC_NO_PROTOTYPES -DLTM_DESC -D_REENTRANT -D_GNU_SOURCE -O2 =auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fPIC   -g -DARGTYPE=4 -c ltc/ciphers/anubis.c -o ltc/ciphers/anubis.o
gcc: error: =auto: No such file or directory
make[1]: *** [Makefile:196: ltc/ciphers/anubis.o] Error 1
make[1]: Leaving directory '/root/.cpanm/work/1606752895.2028/CryptX-0.069/src'
make: *** [Makefile:1941: src/liballinone.a] Error 2
FAIL
```

With the patch applied, it builds & passes tests.