### PR TITLE
Isolate libtomcrypt 'der_*' functions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,6 +62,10 @@ else {
     MYEXTLIB => "src/liballinone$Config{lib_ext}",
     clean    => { 'FILES' => join(' ', @myobjs, "src/liballinone$Config{lib_ext}") },
   );
+
+  if ($^O ne 'MSWin32' && $Config{ld} =~ /gcc|g\+\+/) {
+     push @EUMM_INC_LIB, (LDDLFLAGS => "$Config{lddlflags} -Wl,--exclude-libs,ALL");
+  }
 }
 
 my %eumm_args = (


### PR DESCRIPTION
When compiling Perl or a binary with different versions
of tomcrypt this is going to have unexpected behaviors
as we cannot guarantee which flavor of the C function is used.

This changeset is isolating all the 'der_*' C functions
by adding a prefix 'cryptx_der_*' so they are unique
and would not conflict with another library linked to our binary.

Recipe replacement rules applied:
    replace ' der_'  ' cryptx_der_'
    replace '(der_'  '(cryptx_der_'
    replace ')der_'  ')cryptx_der_'
    replace '!der_' '!cryptx_der_'
    replace '=der_' '=cryptx_der_'
    replace '= der_' '= cryptx_der_'
    replace 'cryptx_der_to_pem' 'der_to_pem' lib/**/*..pm

Note: we should consider adding this to src/update-libtom.pl