### PR TITLE
non-Linux CI

### DIFF
--- a/.github/workflows/combined.yml
+++ b/.github/workflows/combined.yml
@@ -1,4 +1,5 @@
-name: linux
+name: combined
+
 on:
   push:
     branches:
@@ -6,8 +7,9 @@ on:
     tags-ignore:
       - '*'
   pull_request:
+
 jobs:
-  perl:
+  ubuntu:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,6 +32,28 @@ jobs:
       - name: Install dependencies
         run: |
           cpanm -n --installdeps .
+      - name: Run build
+        run: |
+          perl Makefile.PL
+          make -j4
+        env:
+          AUTHOR_MODE: 1
+      - name: Run tests
+        run: prove -bv t
+        env:
+          AUTHOR_MODE: 1
+
+  mac:
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Perl
+        run: brew install perl
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: curl -L https://cpanmin.us | perl - --notest --installdeps .
       - name: Run build
         run: |
           perl Makefile.PL

--- a/.github/workflows/combined.yml
+++ b/.github/workflows/combined.yml
@@ -64,3 +64,58 @@ jobs:
         run: prove -bv t
         env:
           AUTHOR_MODE: 1
+
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Perl
+        run: |
+          choco install strawberryperl
+          echo 'C:\strawberry\c\bin' >> $GITHUB_PATH
+          echo 'C:\strawberry\perl\site\bin' >> $GITHUB_PATH
+          echo 'C:\strawberry\perl\bin' >> $GITHUB_PATH
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: curl -L https://cpanmin.us | perl - --notest --installdeps .
+      - name: Run build
+        run: |
+          perl Makefile.PL
+          make -j4
+        env:
+          AUTHOR_MODE: 1
+      - name: Run tests
+        run: prove -bv t
+        env:
+          AUTHOR_MODE: 1
+
+  cygwin:
+    runs-on: windows-latest
+
+    steps:
+      - name: Set up Cygwin
+        uses: egor-tensin/setup-cygwin@v3
+        with:
+            platform: x64
+            packages: perl_base perl-ExtUtils-MakeMaker make gcc-g++ bash
+      - uses: actions/checkout@v2
+      - run: perl -V
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      - run: cpan App::cpanminus
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      - name: Install Dependencies
+        run: cd $GITHUB_WORKSPACE; cpanm --verbose --notest --installdeps .
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      - name: perl Makefile.PL
+        run: cd $GITHUB_WORKSPACE; perl Makefile.PL
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      - name: make
+        run: cd $GITHUB_WORKSPACE; make -j4
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+      - name: make test
+        run: cd $GITHUB_WORKSPACE; prove -bv t
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        env:
+          AUTHOR_MODE: 1


### PR DESCRIPTION
2 commits:  the first adds just macOS CI, per [request](https://github.com/DCIT/perl-CryptX/commit/aa2b20e9ff624b214264035ac128b452972c815d#commitcomment-62749249).

The 2nd commit adds Windows & Cygwin. Both of these fail; the failures may or may not be legitimate.