### PR TITLE
ltc: fix aesni flag handling

### DIFF
--- a/src/ltc/headers/tomcrypt_cfg.h
+++ b/src/ltc/headers/tomcrypt_cfg.h
@@ -96,6 +96,9 @@ LTC_EXPORT int   LTC_CALL XSTRCMP(const char *s1, const char *s2);
          #define LTC_AMD64_SSE4_1
       #endif
    #endif
+   #if defined(__AES__)
+       #define LTC_AMD64_AES_NI
+   #endif
 #endif
 
 /* detect PPC32 */

--- a/src/ltc/headers/tomcrypt_private.h
+++ b/src/ltc/headers/tomcrypt_private.h
@@ -110,7 +110,7 @@ typedef struct
 
 /* tomcrypt_cipher.h */
 
-#if defined(LTC_AES_NI) && defined(LTC_AMD64_SSE4_1)
+#if defined(LTC_AES_NI) && defined(LTC_AMD64_AES_NI)
 #define LTC_HAS_AES_NI
 #endif
 

--- a/src/ltc/misc/crypt/crypt.c
+++ b/src/ltc/misc/crypt/crypt.c
@@ -419,7 +419,7 @@ const char *crypt_build_settings =
 #if defined(LTC_ADLER32)
     " ADLER32 "
 #endif
-#if defined(LTC_AES_NI) && defined(LTC_AMD64_SSE4_1)
+#if defined(LTC_AES_NI) && defined(LTC_AMD64_AES_NI)
     " AES-NI "
 #endif
 #if defined(LTC_BASE64)


### PR DESCRIPTION
The code was assuming that SEE 4.1 implies AESNI.

Bug: https://bugs.gentoo.org/916387