### PR TITLE
Drop -msse4.1 -maes for libtomcrypt

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ else {
     $ver1 ||= $1 if $Config{gccversion} =~ /^([0-9]+)\./; # gccversion='10.2.0'
     $ver1 ||= $1 if $Config{gccversion} =~ /LLVM ([0-9]+)\./i; # gccversion='Apple LLVM 14.0.0 (clang-1400.0.29.202)'
     $ver1 ||= $1 if $Config{gccversion} =~ /Clang ([0-9]+)\./i; # gccversion='FreeBSD Clang 13.0.0 (git@github.com:llvm/llvm-project.git llvmorg-13.0.0-0-gd7b669b3a303)' or 'OpenBSD Clang 13.0.0'
-    $mycflags .= " -DLTC_AES_NI -msse4.1 -maes" if $ver1 > 4; # supported since gcc-4.4
+    $mycflags .= " -DLTC_AES_NI" if $ver1 > 4; # target attributes are supported since gcc-4.9
   }
 
   #FIX: this is particularly useful for Debian https://github.com/DCIT/perl-CryptX/pull/39


### PR DESCRIPTION
These flags are no longer necessary and cause problems on CPUs without SSE4.1 or AES-NI.

Also update a comment.

I hope the gcc version in the updated comment is correct. I based it on https://gcc.gnu.org/gcc-4.9/changes.html:

> It is now possible to call x86 intrinsics from select functions in a file that are tagged with the corresponding target attribute without having to compile the entire file with the -mxxx option.