### PR TITLE
LTC_AES_NI patch for issue #112

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ else {
     $ver1 ||= $1 if $Config{gccversion} =~ /^([0-9]+)\./; # gccversion='10.2.0'
     $ver1 ||= $1 if $Config{gccversion} =~ /LLVM ([0-9]+)\./i; # gccversion='Apple LLVM 14.0.0 (clang-1400.0.29.202)'
     $ver1 ||= $1 if $Config{gccversion} =~ /Clang ([0-9]+)\./i; # gccversion='FreeBSD Clang 13.0.0 (git@github.com:llvm/llvm-project.git llvmorg-13.0.0-0-gd7b669b3a303)' or 'OpenBSD Clang 13.0.0'
-    $mycflags .= " -DLTC_AES_NI" if $ver1 > 4; # target attributes are supported since gcc-4.9
+    $mycflags .= " -DLTC_AES_NI" if $ver1 > 4 && $ver1 < 16; # target attributes are supported since gcc-4.9
   }
 
   #FIX: this is particularly useful for Debian https://github.com/DCIT/perl-CryptX/pull/39

--- a/lib/Crypt/AuthEnc.pm
+++ b/lib/Crypt/AuthEnc.pm
@@ -2,7 +2,7 @@ package Crypt::AuthEnc;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 ### not used
 

--- a/lib/Crypt/AuthEnc/CCM.pm
+++ b/lib/Crypt/AuthEnc/CCM.pm
@@ -2,7 +2,7 @@ package Crypt::AuthEnc::CCM;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( ccm_encrypt_authenticate ccm_decrypt_verify )] );

--- a/lib/Crypt/AuthEnc/ChaCha20Poly1305.pm
+++ b/lib/Crypt/AuthEnc/ChaCha20Poly1305.pm
@@ -2,7 +2,7 @@ package Crypt::AuthEnc::ChaCha20Poly1305;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( chacha20poly1305_encrypt_authenticate chacha20poly1305_decrypt_verify )] );

--- a/lib/Crypt/AuthEnc/EAX.pm
+++ b/lib/Crypt/AuthEnc/EAX.pm
@@ -2,7 +2,7 @@ package Crypt::AuthEnc::EAX;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( eax_encrypt_authenticate eax_decrypt_verify )] );

--- a/lib/Crypt/AuthEnc/GCM.pm
+++ b/lib/Crypt/AuthEnc/GCM.pm
@@ -2,7 +2,7 @@ package Crypt::AuthEnc::GCM;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( gcm_encrypt_authenticate gcm_decrypt_verify )] );

--- a/lib/Crypt/AuthEnc/OCB.pm
+++ b/lib/Crypt/AuthEnc/OCB.pm
@@ -2,7 +2,7 @@ package Crypt::AuthEnc::OCB;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( ocb_encrypt_authenticate ocb_decrypt_verify )] );

--- a/lib/Crypt/Checksum.pm
+++ b/lib/Crypt/Checksum.pm
@@ -2,7 +2,7 @@ package Crypt::Checksum;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw/ adler32_data adler32_data_hex adler32_data_int adler32_file adler32_file_hex adler32_file_int

--- a/lib/Crypt/Checksum/Adler32.pm
+++ b/lib/Crypt/Checksum/Adler32.pm
@@ -2,7 +2,7 @@ package Crypt::Checksum::Adler32;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Checksum Exporter);
 our %EXPORT_TAGS = ( all => [qw( adler32_data adler32_data_hex adler32_data_int adler32_file adler32_file_hex adler32_file_int )] );

--- a/lib/Crypt/Checksum/CRC32.pm
+++ b/lib/Crypt/Checksum/CRC32.pm
@@ -2,7 +2,7 @@ package Crypt::Checksum::CRC32;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Checksum Exporter);
 our %EXPORT_TAGS = ( all => [qw( crc32_data crc32_data_hex crc32_data_int crc32_file crc32_file_hex crc32_file_int )] );

--- a/lib/Crypt/Cipher.pm
+++ b/lib/Crypt/Cipher.pm
@@ -2,7 +2,7 @@ package Crypt::Cipher;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Carp;
 $Carp::Internal{(__PACKAGE__)}++;

--- a/lib/Crypt/Cipher/AES.pm
+++ b/lib/Crypt/Cipher/AES.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::AES;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Anubis.pm
+++ b/lib/Crypt/Cipher/Anubis.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Anubis;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Blowfish.pm
+++ b/lib/Crypt/Cipher/Blowfish.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Blowfish;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/CAST5.pm
+++ b/lib/Crypt/Cipher/CAST5.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::CAST5;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Camellia.pm
+++ b/lib/Crypt/Cipher/Camellia.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Camellia;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/DES.pm
+++ b/lib/Crypt/Cipher/DES.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::DES;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/DES_EDE.pm
+++ b/lib/Crypt/Cipher/DES_EDE.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::DES_EDE;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/IDEA.pm
+++ b/lib/Crypt/Cipher/IDEA.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::IDEA;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/KASUMI.pm
+++ b/lib/Crypt/Cipher/KASUMI.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::KASUMI;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Khazad.pm
+++ b/lib/Crypt/Cipher/Khazad.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Khazad;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/MULTI2.pm
+++ b/lib/Crypt/Cipher/MULTI2.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::MULTI2;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Noekeon.pm
+++ b/lib/Crypt/Cipher/Noekeon.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Noekeon;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/RC2.pm
+++ b/lib/Crypt/Cipher/RC2.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::RC2;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/RC5.pm
+++ b/lib/Crypt/Cipher/RC5.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::RC5;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/RC6.pm
+++ b/lib/Crypt/Cipher/RC6.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::RC6;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/SAFERP.pm
+++ b/lib/Crypt/Cipher/SAFERP.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::SAFERP;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/SAFER_K128.pm
+++ b/lib/Crypt/Cipher/SAFER_K128.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::SAFER_K128;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/SAFER_K64.pm
+++ b/lib/Crypt/Cipher/SAFER_K64.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::SAFER_K64;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/SAFER_SK128.pm
+++ b/lib/Crypt/Cipher/SAFER_SK128.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::SAFER_SK128;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/SAFER_SK64.pm
+++ b/lib/Crypt/Cipher/SAFER_SK64.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::SAFER_SK64;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/SEED.pm
+++ b/lib/Crypt/Cipher/SEED.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::SEED;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Serpent.pm
+++ b/lib/Crypt/Cipher/Serpent.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Serpent;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Skipjack.pm
+++ b/lib/Crypt/Cipher/Skipjack.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Skipjack;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/Twofish.pm
+++ b/lib/Crypt/Cipher/Twofish.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::Twofish;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Cipher/XTEA.pm
+++ b/lib/Crypt/Cipher/XTEA.pm
@@ -4,7 +4,7 @@ package Crypt::Cipher::XTEA;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Cipher);
 

--- a/lib/Crypt/Digest.pm
+++ b/lib/Crypt/Digest.pm
@@ -2,7 +2,7 @@ package Crypt::Digest;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( digest_data digest_data_hex digest_data_b64 digest_data_b64u digest_file digest_file_hex digest_file_b64 digest_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2b_160.pm
+++ b/lib/Crypt/Digest/BLAKE2b_160.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2b_160;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2b_160 blake2b_160_hex blake2b_160_b64 blake2b_160_b64u blake2b_160_file blake2b_160_file_hex blake2b_160_file_b64 blake2b_160_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2b_256.pm
+++ b/lib/Crypt/Digest/BLAKE2b_256.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2b_256;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2b_256 blake2b_256_hex blake2b_256_b64 blake2b_256_b64u blake2b_256_file blake2b_256_file_hex blake2b_256_file_b64 blake2b_256_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2b_384.pm
+++ b/lib/Crypt/Digest/BLAKE2b_384.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2b_384;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2b_384 blake2b_384_hex blake2b_384_b64 blake2b_384_b64u blake2b_384_file blake2b_384_file_hex blake2b_384_file_b64 blake2b_384_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2b_512.pm
+++ b/lib/Crypt/Digest/BLAKE2b_512.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2b_512;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2b_512 blake2b_512_hex blake2b_512_b64 blake2b_512_b64u blake2b_512_file blake2b_512_file_hex blake2b_512_file_b64 blake2b_512_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2s_128.pm
+++ b/lib/Crypt/Digest/BLAKE2s_128.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2s_128;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2s_128 blake2s_128_hex blake2s_128_b64 blake2s_128_b64u blake2s_128_file blake2s_128_file_hex blake2s_128_file_b64 blake2s_128_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2s_160.pm
+++ b/lib/Crypt/Digest/BLAKE2s_160.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2s_160;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2s_160 blake2s_160_hex blake2s_160_b64 blake2s_160_b64u blake2s_160_file blake2s_160_file_hex blake2s_160_file_b64 blake2s_160_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2s_224.pm
+++ b/lib/Crypt/Digest/BLAKE2s_224.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2s_224;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2s_224 blake2s_224_hex blake2s_224_b64 blake2s_224_b64u blake2s_224_file blake2s_224_file_hex blake2s_224_file_b64 blake2s_224_file_b64u )] );

--- a/lib/Crypt/Digest/BLAKE2s_256.pm
+++ b/lib/Crypt/Digest/BLAKE2s_256.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::BLAKE2s_256;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2s_256 blake2s_256_hex blake2s_256_b64 blake2s_256_b64u blake2s_256_file blake2s_256_file_hex blake2s_256_file_b64 blake2s_256_file_b64u )] );

--- a/lib/Crypt/Digest/CHAES.pm
+++ b/lib/Crypt/Digest/CHAES.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::CHAES;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( chaes chaes_hex chaes_b64 chaes_b64u chaes_file chaes_file_hex chaes_file_b64 chaes_file_b64u )] );

--- a/lib/Crypt/Digest/Keccak224.pm
+++ b/lib/Crypt/Digest/Keccak224.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::Keccak224;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( keccak224 keccak224_hex keccak224_b64 keccak224_b64u keccak224_file keccak224_file_hex keccak224_file_b64 keccak224_file_b64u )] );

--- a/lib/Crypt/Digest/Keccak256.pm
+++ b/lib/Crypt/Digest/Keccak256.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::Keccak256;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( keccak256 keccak256_hex keccak256_b64 keccak256_b64u keccak256_file keccak256_file_hex keccak256_file_b64 keccak256_file_b64u )] );

--- a/lib/Crypt/Digest/Keccak384.pm
+++ b/lib/Crypt/Digest/Keccak384.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::Keccak384;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( keccak384 keccak384_hex keccak384_b64 keccak384_b64u keccak384_file keccak384_file_hex keccak384_file_b64 keccak384_file_b64u )] );

--- a/lib/Crypt/Digest/Keccak512.pm
+++ b/lib/Crypt/Digest/Keccak512.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::Keccak512;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( keccak512 keccak512_hex keccak512_b64 keccak512_b64u keccak512_file keccak512_file_hex keccak512_file_b64 keccak512_file_b64u )] );

--- a/lib/Crypt/Digest/MD2.pm
+++ b/lib/Crypt/Digest/MD2.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::MD2;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( md2 md2_hex md2_b64 md2_b64u md2_file md2_file_hex md2_file_b64 md2_file_b64u )] );

--- a/lib/Crypt/Digest/MD4.pm
+++ b/lib/Crypt/Digest/MD4.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::MD4;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( md4 md4_hex md4_b64 md4_b64u md4_file md4_file_hex md4_file_b64 md4_file_b64u )] );

--- a/lib/Crypt/Digest/MD5.pm
+++ b/lib/Crypt/Digest/MD5.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::MD5;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( md5 md5_hex md5_b64 md5_b64u md5_file md5_file_hex md5_file_b64 md5_file_b64u )] );

--- a/lib/Crypt/Digest/RIPEMD128.pm
+++ b/lib/Crypt/Digest/RIPEMD128.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::RIPEMD128;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( ripemd128 ripemd128_hex ripemd128_b64 ripemd128_b64u ripemd128_file ripemd128_file_hex ripemd128_file_b64 ripemd128_file_b64u )] );

--- a/lib/Crypt/Digest/RIPEMD160.pm
+++ b/lib/Crypt/Digest/RIPEMD160.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::RIPEMD160;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( ripemd160 ripemd160_hex ripemd160_b64 ripemd160_b64u ripemd160_file ripemd160_file_hex ripemd160_file_b64 ripemd160_file_b64u )] );

--- a/lib/Crypt/Digest/RIPEMD256.pm
+++ b/lib/Crypt/Digest/RIPEMD256.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::RIPEMD256;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( ripemd256 ripemd256_hex ripemd256_b64 ripemd256_b64u ripemd256_file ripemd256_file_hex ripemd256_file_b64 ripemd256_file_b64u )] );

--- a/lib/Crypt/Digest/RIPEMD320.pm
+++ b/lib/Crypt/Digest/RIPEMD320.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::RIPEMD320;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( ripemd320 ripemd320_hex ripemd320_b64 ripemd320_b64u ripemd320_file ripemd320_file_hex ripemd320_file_b64 ripemd320_file_b64u )] );

--- a/lib/Crypt/Digest/SHA1.pm
+++ b/lib/Crypt/Digest/SHA1.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA1;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha1 sha1_hex sha1_b64 sha1_b64u sha1_file sha1_file_hex sha1_file_b64 sha1_file_b64u )] );

--- a/lib/Crypt/Digest/SHA224.pm
+++ b/lib/Crypt/Digest/SHA224.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA224;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha224 sha224_hex sha224_b64 sha224_b64u sha224_file sha224_file_hex sha224_file_b64 sha224_file_b64u )] );

--- a/lib/Crypt/Digest/SHA256.pm
+++ b/lib/Crypt/Digest/SHA256.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA256;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha256 sha256_hex sha256_b64 sha256_b64u sha256_file sha256_file_hex sha256_file_b64 sha256_file_b64u )] );

--- a/lib/Crypt/Digest/SHA384.pm
+++ b/lib/Crypt/Digest/SHA384.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA384;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha384 sha384_hex sha384_b64 sha384_b64u sha384_file sha384_file_hex sha384_file_b64 sha384_file_b64u )] );

--- a/lib/Crypt/Digest/SHA3_224.pm
+++ b/lib/Crypt/Digest/SHA3_224.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA3_224;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha3_224 sha3_224_hex sha3_224_b64 sha3_224_b64u sha3_224_file sha3_224_file_hex sha3_224_file_b64 sha3_224_file_b64u )] );

--- a/lib/Crypt/Digest/SHA3_256.pm
+++ b/lib/Crypt/Digest/SHA3_256.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA3_256;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha3_256 sha3_256_hex sha3_256_b64 sha3_256_b64u sha3_256_file sha3_256_file_hex sha3_256_file_b64 sha3_256_file_b64u )] );

--- a/lib/Crypt/Digest/SHA3_384.pm
+++ b/lib/Crypt/Digest/SHA3_384.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA3_384;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha3_384 sha3_384_hex sha3_384_b64 sha3_384_b64u sha3_384_file sha3_384_file_hex sha3_384_file_b64 sha3_384_file_b64u )] );

--- a/lib/Crypt/Digest/SHA3_512.pm
+++ b/lib/Crypt/Digest/SHA3_512.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA3_512;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha3_512 sha3_512_hex sha3_512_b64 sha3_512_b64u sha3_512_file sha3_512_file_hex sha3_512_file_b64 sha3_512_file_b64u )] );

--- a/lib/Crypt/Digest/SHA512.pm
+++ b/lib/Crypt/Digest/SHA512.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA512;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha512 sha512_hex sha512_b64 sha512_b64u sha512_file sha512_file_hex sha512_file_b64 sha512_file_b64u )] );

--- a/lib/Crypt/Digest/SHA512_224.pm
+++ b/lib/Crypt/Digest/SHA512_224.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA512_224;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha512_224 sha512_224_hex sha512_224_b64 sha512_224_b64u sha512_224_file sha512_224_file_hex sha512_224_file_b64 sha512_224_file_b64u )] );

--- a/lib/Crypt/Digest/SHA512_256.pm
+++ b/lib/Crypt/Digest/SHA512_256.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::SHA512_256;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( sha512_256 sha512_256_hex sha512_256_b64 sha512_256_b64u sha512_256_file sha512_256_file_hex sha512_256_file_b64 sha512_256_file_b64u )] );

--- a/lib/Crypt/Digest/SHAKE.pm
+++ b/lib/Crypt/Digest/SHAKE.pm
@@ -2,7 +2,7 @@ package Crypt::Digest::SHAKE;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Carp;
 $Carp::Internal{(__PACKAGE__)}++;

--- a/lib/Crypt/Digest/Tiger192.pm
+++ b/lib/Crypt/Digest/Tiger192.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::Tiger192;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( tiger192 tiger192_hex tiger192_b64 tiger192_b64u tiger192_file tiger192_file_hex tiger192_file_b64 tiger192_file_b64u )] );

--- a/lib/Crypt/Digest/Whirlpool.pm
+++ b/lib/Crypt/Digest/Whirlpool.pm
@@ -4,7 +4,7 @@ package Crypt::Digest::Whirlpool;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Digest Exporter);
 our %EXPORT_TAGS = ( all => [qw( whirlpool whirlpool_hex whirlpool_b64 whirlpool_b64u whirlpool_file whirlpool_file_hex whirlpool_file_b64 whirlpool_file_b64u )] );

--- a/lib/Crypt/KeyDerivation.pm
+++ b/lib/Crypt/KeyDerivation.pm
@@ -2,7 +2,7 @@ package Crypt::KeyDerivation;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw(pbkdf1 pbkdf2 hkdf hkdf_expand hkdf_extract)] );

--- a/lib/Crypt/Mac.pm
+++ b/lib/Crypt/Mac.pm
@@ -2,7 +2,7 @@ package Crypt::Mac;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Carp;
 $Carp::Internal{(__PACKAGE__)}++;

--- a/lib/Crypt/Mac/BLAKE2b.pm
+++ b/lib/Crypt/Mac/BLAKE2b.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::BLAKE2b;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2b blake2b_hex blake2b_b64 blake2b_b64u )] );

--- a/lib/Crypt/Mac/BLAKE2s.pm
+++ b/lib/Crypt/Mac/BLAKE2s.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::BLAKE2s;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( blake2s blake2s_hex blake2s_b64 blake2s_b64u )] );

--- a/lib/Crypt/Mac/F9.pm
+++ b/lib/Crypt/Mac/F9.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::F9;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( f9 f9_hex f9_b64 f9_b64u )] );

--- a/lib/Crypt/Mac/HMAC.pm
+++ b/lib/Crypt/Mac/HMAC.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::HMAC;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( hmac hmac_hex hmac_b64 hmac_b64u )] );

--- a/lib/Crypt/Mac/OMAC.pm
+++ b/lib/Crypt/Mac/OMAC.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::OMAC;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( omac omac_hex omac_b64 omac_b64u )] );

--- a/lib/Crypt/Mac/PMAC.pm
+++ b/lib/Crypt/Mac/PMAC.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::PMAC;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( pmac pmac_hex pmac_b64 pmac_b64u )] );

--- a/lib/Crypt/Mac/Pelican.pm
+++ b/lib/Crypt/Mac/Pelican.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::Pelican;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( pelican pelican_hex pelican_b64 pelican_b64u )] );

--- a/lib/Crypt/Mac/Poly1305.pm
+++ b/lib/Crypt/Mac/Poly1305.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::Poly1305;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( poly1305 poly1305_hex poly1305_b64 poly1305_b64u )] );

--- a/lib/Crypt/Mac/XCBC.pm
+++ b/lib/Crypt/Mac/XCBC.pm
@@ -4,7 +4,7 @@ package Crypt::Mac::XCBC;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::Mac Exporter);
 our %EXPORT_TAGS = ( all => [qw( xcbc xcbc_hex xcbc_b64 xcbc_b64u )] );

--- a/lib/Crypt/Misc.pm
+++ b/lib/Crypt/Misc.pm
@@ -2,7 +2,7 @@ package Crypt::Misc;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 use Carp 'croak';

--- a/lib/Crypt/Mode.pm
+++ b/lib/Crypt/Mode.pm
@@ -2,7 +2,7 @@ package Crypt::Mode;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 ### not used
 

--- a/lib/Crypt/Mode/CBC.pm
+++ b/lib/Crypt/Mode/CBC.pm
@@ -4,7 +4,7 @@ package Crypt::Mode::CBC;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Crypt::Cipher;
 

--- a/lib/Crypt/Mode/CFB.pm
+++ b/lib/Crypt/Mode/CFB.pm
@@ -4,7 +4,7 @@ package Crypt::Mode::CFB;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Crypt::Cipher;
 

--- a/lib/Crypt/Mode/CTR.pm
+++ b/lib/Crypt/Mode/CTR.pm
@@ -4,7 +4,7 @@ package Crypt::Mode::CTR;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Crypt::Cipher;
 

--- a/lib/Crypt/Mode/ECB.pm
+++ b/lib/Crypt/Mode/ECB.pm
@@ -4,7 +4,7 @@ package Crypt::Mode::ECB;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Crypt::Cipher;
 

--- a/lib/Crypt/Mode/OFB.pm
+++ b/lib/Crypt/Mode/OFB.pm
@@ -4,7 +4,7 @@ package Crypt::Mode::OFB;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Crypt::Cipher;
 

--- a/lib/Crypt/PK.pm
+++ b/lib/Crypt/PK.pm
@@ -2,7 +2,7 @@ package Crypt::PK;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use Carp;
 

--- a/lib/Crypt/PK/DH.pm
+++ b/lib/Crypt/PK/DH.pm
@@ -2,7 +2,7 @@ package Crypt::PK::DH;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( dh_shared_secret )] );

--- a/lib/Crypt/PK/DSA.pm
+++ b/lib/Crypt/PK/DSA.pm
@@ -2,7 +2,7 @@ package Crypt::PK::DSA;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( dsa_encrypt dsa_decrypt dsa_sign_message dsa_verify_message dsa_sign_hash dsa_verify_hash )] );

--- a/lib/Crypt/PK/ECC.pm
+++ b/lib/Crypt/PK/ECC.pm
@@ -2,7 +2,7 @@ package Crypt::PK::ECC;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( ecc_encrypt ecc_decrypt ecc_sign_message ecc_verify_message ecc_sign_hash ecc_verify_hash ecc_shared_secret )] );

--- a/lib/Crypt/PK/Ed25519.pm
+++ b/lib/Crypt/PK/Ed25519.pm
@@ -2,7 +2,7 @@ package Crypt::PK::Ed25519;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( )] );

--- a/lib/Crypt/PK/RSA.pm
+++ b/lib/Crypt/PK/RSA.pm
@@ -2,7 +2,7 @@ package Crypt::PK::RSA;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw(rsa_encrypt rsa_decrypt rsa_sign_message rsa_verify_message rsa_sign_hash rsa_verify_hash)] );

--- a/lib/Crypt/PK/X25519.pm
+++ b/lib/Crypt/PK/X25519.pm
@@ -2,7 +2,7 @@ package Crypt::PK::X25519;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw( )] );

--- a/lib/Crypt/PRNG.pm
+++ b/lib/Crypt/PRNG.pm
@@ -2,7 +2,7 @@ package Crypt::PRNG;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require Exporter; our @ISA = qw(Exporter); ### use Exporter 5.57 'import';
 our %EXPORT_TAGS = ( all => [qw(random_bytes random_bytes_hex random_bytes_b64 random_bytes_b64u random_string random_string_from rand irand)] );

--- a/lib/Crypt/PRNG/ChaCha20.pm
+++ b/lib/Crypt/PRNG/ChaCha20.pm
@@ -2,7 +2,7 @@ package Crypt::PRNG::ChaCha20;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::PRNG Exporter);
 our %EXPORT_TAGS = ( all => [qw(random_bytes random_bytes_hex random_bytes_b64 random_bytes_b64u random_string random_string_from rand irand)] );

--- a/lib/Crypt/PRNG/Fortuna.pm
+++ b/lib/Crypt/PRNG/Fortuna.pm
@@ -2,7 +2,7 @@ package Crypt::PRNG::Fortuna;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::PRNG Exporter);
 our %EXPORT_TAGS = ( all => [qw(random_bytes random_bytes_hex random_bytes_b64 random_bytes_b64u random_string random_string_from rand irand)] );

--- a/lib/Crypt/PRNG/RC4.pm
+++ b/lib/Crypt/PRNG/RC4.pm
@@ -2,7 +2,7 @@ package Crypt::PRNG::RC4;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::PRNG Exporter);
 our %EXPORT_TAGS = ( all => [qw(random_bytes random_bytes_hex random_bytes_b64 random_bytes_b64u random_string random_string_from rand irand)] );

--- a/lib/Crypt/PRNG/Sober128.pm
+++ b/lib/Crypt/PRNG/Sober128.pm
@@ -2,7 +2,7 @@ package Crypt::PRNG::Sober128;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::PRNG Exporter);
 our %EXPORT_TAGS = ( all => [qw(random_bytes random_bytes_hex random_bytes_b64 random_bytes_b64u random_string random_string_from rand irand)] );

--- a/lib/Crypt/PRNG/Yarrow.pm
+++ b/lib/Crypt/PRNG/Yarrow.pm
@@ -2,7 +2,7 @@ package Crypt::PRNG::Yarrow;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use base qw(Crypt::PRNG Exporter);
 our %EXPORT_TAGS = ( all => [qw(random_bytes random_bytes_hex random_bytes_b64 random_bytes_b64u random_string random_string_from rand irand)] );

--- a/lib/Crypt/Stream/ChaCha.pm
+++ b/lib/Crypt/Stream/ChaCha.pm
@@ -2,7 +2,7 @@ package Crypt::Stream::ChaCha;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use CryptX;
 

--- a/lib/Crypt/Stream/RC4.pm
+++ b/lib/Crypt/Stream/RC4.pm
@@ -2,7 +2,7 @@ package Crypt::Stream::RC4;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use CryptX;
 

--- a/lib/Crypt/Stream/Rabbit.pm
+++ b/lib/Crypt/Stream/Rabbit.pm
@@ -2,7 +2,7 @@ package Crypt::Stream::Rabbit;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use CryptX;
 

--- a/lib/Crypt/Stream/Salsa20.pm
+++ b/lib/Crypt/Stream/Salsa20.pm
@@ -2,7 +2,7 @@ package Crypt::Stream::Salsa20;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use CryptX;
 

--- a/lib/Crypt/Stream/Sober128.pm
+++ b/lib/Crypt/Stream/Sober128.pm
@@ -2,7 +2,7 @@ package Crypt::Stream::Sober128;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use CryptX;
 

--- a/lib/Crypt/Stream/Sosemanuk.pm
+++ b/lib/Crypt/Stream/Sosemanuk.pm
@@ -2,7 +2,7 @@ package Crypt::Stream::Sosemanuk;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use CryptX;
 

--- a/lib/CryptX.pm
+++ b/lib/CryptX.pm
@@ -2,7 +2,7 @@ package CryptX;
 
 use strict;
 use warnings ;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 require XSLoader;
 XSLoader::load('CryptX', $VERSION);

--- a/lib/Math/BigInt/LTM.pm
+++ b/lib/Math/BigInt/LTM.pm
@@ -2,7 +2,7 @@ package Math::BigInt::LTM;
 
 use strict;
 use warnings;
-our $VERSION = '0.084';
+our $VERSION = '0.084_001';
 
 use CryptX;
 use Carp;


### PR DESCRIPTION
https://github.com/DCIT/perl-CryptX/issues/112

Fix this error on OSX Sequoia:

```
cd src && make ARFLAGS="cr" RANLIB="ranlib" AR="ar" CC="cc" LIB_EXT=.a OBJ_EXT=.o CFLAGS="  -g -pipe -DPERL_USE_SAFE_PUTENV   -Os  -DLTC_AES_NI"
cc -Iltm -Iltc/headers -DLTC_SOURCE -DLTC_NO_TEST -DLTC_NO_PROTOTYPES -DLTM_DESC -g -pipe -DPERL_USE_SAFE_PUTENV   -Os  -DLTC_AES_NI -DARGTYPE=4 -c ltc/ciphers/aes/aes.c -o ltc/ciphers/aes/aes.o
cc -Iltm -Iltc/headers -DLTC_SOURCE -DLTC_NO_TEST -DLTC_NO_PROTOTYPES -DLTM_DESC -g -pipe -DPERL_USE_SAFE_PUTENV   -Os  -DLTC_AES_NI -DARGTYPE=4 -c ltc/ciphers/aes/aes_desc.c -o ltc/ciphers/aes/aes_desc.o
ltc/ciphers/aes/aes_desc.c:67:13: error: invalid output constraint '=a' in asm
   67 |            :"=a"(a), "=b"(b), "=c"(c), "=d"(d)
      |             ^
1 error generated.
make[1]: *** [ltc/ciphers/aes/aes_desc.o] Error 1
make: *** [src/liballinone.a] Error 2
```

The build quit working at perl-CryptX v0.081 under the following perl setup:

```
[hookbot@TestSequoia perl-CryptX]$ perl -V
Summary of my perl5 (revision 5 version 34 subversion 1) configuration:

  Platform:
    osname=darwin
    osvers=24.0
    archname=darwin-thread-multi-2level
    uname='darwin 5dgj7.p1s.plx.sd.apple.com 24.0 darwin kernel version 22.1.0: thu dec 15 17:42:24 pst 2022; root:xnu-8792.41.9.100.2~1development_x86_64 x86_64 '
    config_args='-ds -e -Dprefix=/usr -Dccflags=-g  -pipe  -Dldflags= -Dman3ext=3pm -Duseithreads -Duseshrplib -Dinc_version_list=none -Dcc=cc'
    hint=recommended
    useposix=true
    d_sigaction=define
    useithreads=define
    usemultiplicity=define
    use64bitint=define
    use64bitall=define
    uselongdouble=undef
    usemymalloc=n
    default_inc_excludes_dot=define
  Compiler:
    cc='cc'
    ccflags =' -g -pipe -DPERL_USE_SAFE_PUTENV'
    optimize='-Os'
    cppflags='-g -pipe'
    ccversion=''
    gccversion='Apple LLVM 16.0.0 (clang-1600.0.25.3) [+internal-os]'
    gccosandvers=''
    intsize=4
    longsize=8
    ptrsize=8
    doublesize=8
    byteorder=12345678
    doublekind=3
    d_longlong=define
    longlongsize=8
    d_longdbl=define
    longdblsize=16
    longdblkind=3
    ivtype='long'
    ivsize=8
    nvtype='double'
    nvsize=8
    Off_t='off_t'
    lseeksize=8
    alignbytes=8
    prototype=define
  Linker and Libraries:
    ld='cc'
    ldflags =' '
    libpth=/AppleInternal/Library/BuildRoots/4b66fb3c-7dd0-11ef-b4fb-4a83e32a47e1/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.Internal.sdk/usr/local/lib /AppleInternal/Library/BuildRoots/4b66fb3c-7dd0-11ef-b4fb-4a83e32a47e1/Applications/Xcode.app/Contents/Developer/Toolchains/OSX15.1.xctoolchain/usr/lib/clang/16/lib /AppleInternal/Library/BuildRoots/4b66fb3c-7dd0-11ef-b4fb-4a83e32a47e1/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.Internal.sdk/usr/lib /AppleInternal/Library/BuildRoots/4b66fb3c-7dd0-11ef-b4fb-4a83e32a47e1/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib /usr/lib /usr/local/lib
    libs=
    perllibs=
    libc=
    so=dylib
    useshrplib=true
    libperl=libperl.dylib
    gnulibc_version=''
  Dynamic Linking:
    dlsrc=dl_dlopen.xs
    dlext=bundle
    d_dlsymun=undef
    ccdlflags=' '
    cccdlflags=' '
    lddlflags=' -bundle -undefined dynamic_lookup'

Characteristics of this binary (from libperl):
  Compile-time options:
    HAS_TIMES
    MULTIPLICITY
    PERLIO_LAYERS
    PERL_COPY_ON_WRITE
    PERL_DONT_CREATE_GVSV
    PERL_IMPLICIT_CONTEXT
    PERL_MALLOC_WRAP
    PERL_OP_PARENT
    PERL_PRESERVE_IVUV
    PERL_USE_SAFE_PUTENV
    USE_64_BIT_ALL
    USE_64_BIT_INT
    USE_ITHREADS
    USE_LARGE_FILES
    USE_LOCALE
    USE_LOCALE_COLLATE
    USE_LOCALE_CTYPE
    USE_LOCALE_NUMERIC
    USE_LOCALE_TIME
    USE_PERLIO
    USE_PERL_ATOF
    USE_REENTRANT_API
    USE_THREAD_SAFE_LOCALE
  Locally applied patches:
    /Library/Perl/Updates/<version> comes before system perl directories
    installprivlib and installarchlib points to the Updates directory
  Built under darwin
  Compiled at Sep 28 2024 16:20:11
  @INC:
    /Library/Perl/5.34/darwin-thread-multi-2level
    /Library/Perl/5.34
    /Network/Library/Perl/5.34/darwin-thread-multi-2level
    /Network/Library/Perl/5.34
    /Library/Perl/Updates/5.34.1
    /System/Library/Perl/5.34/darwin-thread-multi-2level
    /System/Library/Perl/5.34
    /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level
    /System/Library/Perl/Extras/5.34
[hookbot@TestSequoia perl-CryptX]$
```

Another work-around is to downgrade from v0.084 to v0.080.