### PR TITLE
Add support for RFC6979 deterministic signatures

### DIFF
--- a/inc/CryptX_PK_ECC.xs.inc
+++ b/inc/CryptX_PK_ECC.xs.inc
@@ -553,6 +553,21 @@ recovery_pub(Crypt::PK::ECC self, SV * sig, SV* hash, SV* recid = NULL)
         RETVAL
 
 void
+set_rfc6979_hash_alg(Crypt::PK::ECC self, const char * hash_name = "SHA1")
+    PPCODE:
+    {
+        int hash_id;
+        const char *normalized_hash_name;
+
+        hash_id = cryptx_internal_find_hash(hash_name);
+        if (hash_id == -1) croak("FATAL: find_hash failed for '%s'", hash_name);
+        normalized_hash_name = hash_descriptor[hash_id].name;
+
+        ECC_SET_RFC6979_HASH_ALG(&self->key, normalized_hash_name);
+        XPUSHs(ST(0)); /* return self */
+    }
+
+void
 DESTROY(Crypt::PK::ECC self)
     CODE:
         if (self->key.type != -1) { ecc_free(&self->key); self->key.type = -1; }

--- a/inc/CryptX_PK_ECC.xs.inc
+++ b/inc/CryptX_PK_ECC.xs.inc
@@ -409,7 +409,7 @@ decrypt(Crypt::PK::ECC self, SV * data)
         RETVAL
 
 SV *
-sign_hash(Crypt::PK::ECC self, SV * data, const char * hash_name = "SHA1")
+sign_hash(Crypt::PK::ECC self, SV * data, const char * hash_name = NULL, const char * hash_rfc6979_name = NULL)
     ALIAS:
         sign_hash_rfc7518    = 3
         sign_message         = 1
@@ -417,13 +417,23 @@ sign_hash(Crypt::PK::ECC self, SV * data, const char * hash_name = "SHA1")
         sign_hash_eth        = 4
     CODE:
     {
-        int rv, id;
+        int rv, id, hash_rfc6979_id;
         unsigned char buffer[1024], tmp[MAXBLOCKSIZE], *data_ptr = NULL;
         unsigned long tmp_len = MAXBLOCKSIZE, buffer_len = 1024;
         STRLEN data_len = 0;
 
+        // Handle dual signature modes for backward compatibility
+        // For sign_hash_*: if only 2 params passed, treat second as RFC6979 hash
+        if ((ix == 0 || ix == 3 || ix == 4) && hash_name != NULL && hash_rfc6979_name == NULL) {
+          hash_rfc6979_name = hash_name;
+        }
+
         data_ptr = (unsigned char *)SvPVbyte(data, data_len);
         if (ix == 1 || ix == 2) {
+          // for backward compatibility, if hash_name is NULL, use SHA1
+          if (hash_name == NULL) {
+            hash_name = "SHA1";
+          }
           id = cryptx_internal_find_hash(hash_name);
           if (id == -1) croak("FATAL: find_hash failed for '%s'", hash_name);
           rv = hash_memory(id, data_ptr, (unsigned long)data_len, tmp, &tmp_len);
@@ -431,6 +441,18 @@ sign_hash(Crypt::PK::ECC self, SV * data, const char * hash_name = "SHA1")
           data_ptr = tmp;
           data_len = tmp_len;
         }
+
+        if (hash_rfc6979_name != NULL) {
+          hash_rfc6979_id = cryptx_internal_find_hash(hash_rfc6979_name);
+          if (hash_rfc6979_id == -1) croak("FATAL: find_hash failed for rfc6979 hash '%s'", hash_rfc6979_name);
+          ECC_SET_RFC6979_HASH_ALG(&self->key, hash_descriptor[hash_rfc6979_id].name);
+        } else {
+          // Clear any previously set RFC6979 hash to ensure non-deterministic signing
+          // when RFC6979 parameter is not provided. This prevents hidden state from
+          // previous method calls affecting current signature behavior.
+          ECC_SET_RFC6979_HASH_ALG(&self->key, NULL);
+        }
+
         if (ix == 2 || ix == 3) {
           rv = ecc_sign_hash_rfc7518(data_ptr, (unsigned long)data_len, buffer, &buffer_len,
                              &self->pstate, self->pindex,
@@ -551,21 +573,6 @@ recovery_pub(Crypt::PK::ECC self, SV * sig, SV* hash, SV* recid = NULL)
     }
     OUTPUT:
         RETVAL
-
-void
-set_rfc6979_hash_alg(Crypt::PK::ECC self, const char * hash_name = "SHA1")
-    PPCODE:
-    {
-        int hash_id;
-        const char *normalized_hash_name;
-
-        hash_id = cryptx_internal_find_hash(hash_name);
-        if (hash_id == -1) croak("FATAL: find_hash failed for '%s'", hash_name);
-        normalized_hash_name = hash_descriptor[hash_id].name;
-
-        ECC_SET_RFC6979_HASH_ALG(&self->key, normalized_hash_name);
-        XPUSHs(ST(0)); /* return self */
-    }
 
 void
 DESTROY(Crypt::PK::ECC self)

--- a/lib/Crypt/PK/ECC.pm
+++ b/lib/Crypt/PK/ECC.pm
@@ -851,7 +851,11 @@ to get a fully RFC-7518-compliant signature.
 =head2 sign_hash
 
  my $pk = Crypt::PK::ECC->new($priv_key_filename);
- my $signature = $priv->sign_hash($message_hash);
+ my $signature = $priv->sign_hash($message_hash, $deterministic_hash_name);
+
+ #NOTE: $deterministic_hash_name can be 'SHA1', 'SHA256' or any other hash supported by Crypt::Digest
+ #      in most cases it will be the same as used to create $message_hash, if not provided non-deterministic
+ #      signature will be created
 
 I<Since: CryptX-0.081>
 
@@ -891,17 +895,6 @@ This method will recover public key from ECDSA signature in Ethereum format
  my $pk = Crypt::PK::ECC->new($priv_key_filename);
  my $signature = $pk->sign_hash_eth($message_hash);
  my $pub_key = $pk->recovery_pub_eth($sig, $hash)
-
-=head2 set_rfc6979_hash_alg
-
-I<Since: CryptX-0.087>
-
-Set the hash algorithm used for deterministic k generation as per RFC 6979.
-Default is SHA-1, but for better security you should use SHA-256 or stronger.
-
- my $pk = Crypt::PK::ECC->new($priv_key_filename);
- $pk->set_rfc6979_hash_alg('SHA256');
- my $signature = $pk->sign_hash_eth($message_hash);
 
 =head2 recovery_pub
 

--- a/lib/Crypt/PK/ECC.pm
+++ b/lib/Crypt/PK/ECC.pm
@@ -853,7 +853,7 @@ to get a fully RFC-7518-compliant signature.
  my $pk = Crypt::PK::ECC->new($priv_key_filename);
  my $signature = $priv->sign_hash($message_hash);
 
-I<Since: CyrptX-0.081>
+I<Since: CryptX-0.081>
 
 =head2 sign_hash_eth
 
@@ -874,7 +874,7 @@ Same as L<sign_hash|/sign_hash> only the signature format is as defined by L<htt
 
 =head2 verify_hash_rfc7518
 
-I<Since: CyrptX-0.081>
+I<Since: CryptX-0.081>
 
 =head2 verify_hash_eth
 
@@ -891,6 +891,17 @@ This method will recover public key from ECDSA signature in Ethereum format
  my $pk = Crypt::PK::ECC->new($priv_key_filename);
  my $signature = $pk->sign_hash_eth($message_hash);
  my $pub_key = $pk->recovery_pub_eth($sig, $hash)
+
+=head2 set_rfc6979_hash_alg
+
+I<Since: CryptX-0.087>
+
+Set the hash algorithm used for deterministic k generation as per RFC 6979.
+Default is SHA-1, but for better security you should use SHA-256 or stronger.
+
+ my $pk = Crypt::PK::ECC->new($priv_key_filename);
+ $pk->set_rfc6979_hash_alg('SHA256');
+ my $signature = $pk->sign_hash_eth($message_hash);
 
 =head2 recovery_pub
 


### PR DESCRIPTION
This PR adds support for RFC6979 deterministic ECDSA signatures to the Crypt::PK::ECC module by introducing a new set_rfc6979_hash_alg() method, that has been made available after the latest version [bump](https://github.com/DCIT/perl-CryptX/commit/3a9f534958549239ad6dc3e9356ea94fcbf09bf7) for the libtomcrypt

```perl
use Crypt::PK::ECC;

my $ecc = Crypt::PK::ECC->new();
$ecc->generate_key('secp256k1');

# Set RFC6979 hash algorithm for deterministic signatures
$ecc->set_rfc6979_hash_alg('SHA256');

# Sign a message - will produce deterministic signatures
my $signature1 = $ecc->sign_message("Hello World");
my $signature2 = $ecc->sign_message("Hello World");
# $signature1 eq $signature2 (deterministic!)
```

### Context

Standard ECDSA signatures require a high-quality source of randomness. A weak or compromised random number generator can lead to the exposure of the private key. RFC 6979 mitigates this risk by generating the nonce deterministically from the private key and the message hash.

This feature is particularly crucial for applications like blockchain, where signature determinism is often required.
